### PR TITLE
ci: Add test coverage reporting and fix Codecov slug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
         # We dynamically pass the site-packages path from the uv environment using --search-path.
         run: uv run pyre --noninteractive --search-path $(uv run -q python -c "import site; print(site.getsitepackages()[0])") check
 
-      - name: Run Tests
-        run: uv run pytest
+      - name: Run Tests with Coverage
+        run: uv run pytest --cov=src --cov-report=xml --cov-report=term
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: elong0527/py-forestly
+          slug: elong0527/rod


### PR DESCRIPTION
## Summary
- Add coverage reporting to pytest using `--cov` flags to generate XML and terminal coverage reports
- Fix Codecov slug from incorrect `elong0527/py-forestly` to correct `elong0527/rod`

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Confirm coverage reports are generated
- [ ] Verify Codecov integration works with correct repository slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)