### PR TITLE
Release v0.2.0: Pydantic Migration, Enhanced Testing, and Code Quality Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0]
+
+### Added
+- **Centralized Configuration**: Introduced `src/csrlite/common/config.py` with `CsrLiteConfig` Pydantic model for managing global settings (column names, logging levels).
+- **Listing**: Added logging configuration in `src/csrlite/__init__.py`.
+- **Integration Tests**: Added `tests/integration_test_pipeline.py` covering the full pipeline from plan loading to RTF generation.
+- **Extended Testing**: Added `tests/test_plan_extended.py` significantly increasing coverage for `plan.py`.
+
+### Changed
+- **Refactored `count.py`**:
+    - Decoupled calculation from formatting.
+    - Split `count_subject_with_observation` into `count_summary_data` (numeric) and `format_summary_table` (string).
+    - Preserved backward compatibility with a wrapper.
+- **Enhanced `StudyPlan`**:
+    - Migrated `StudyPlan` and related classes (`Keyword`, `Population`, `Observation`, etc.) from `dataclasses` to `Pydantic` models for robust validation.
+    - Improved `KeywordRegistry` to better handle nested polymorphism and legacy `group_label` list structures.
+- **Dependencies**:
+    - Added `structlog` (optional) and standard `logging` integration.
+    - Enforced `pydantic>=2.0.0`.
+
+### Fixed
+- **Static Analysis**: Resolved all `pyre`, `mypy`, and `ruff` errors, including restoring the correct search path for Pyre.
+- **Polars Deprecation**: Fixed `is_in` deprecation warning in `ae_specific.py`.
+- **Bug**: Fixed `TypeError` in `StudyPlan.__str__` where `Dict` was instantiated.
+
+### Removed
+- Removed manual `print` statements in favor of structured logging.
+
+## [0.1.0]
+
+### Added
+- Initial implementation of the csrlite library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csrlite"
-version = "0.1.0"
+version = "0.2.0"
 description = "A hierarchical YAML-based framework for generating Tables, Listings, and Figures in clinical trials"
 authors = [{name = "Clinical Biostatistics Team", email = "biostat@example.com"}]
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -682,7 +682,7 @@ toml = [
 
 [[package]]
 name = "csrlite"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
## Summary
This release introduces significant architectural improvements and enhanced testing for the csrlite library:

- **Pydantic Migration**: Migrated core data models (`StudyPlan`, `Keyword` subclasses) from dataclasses to Pydantic for robust validation
- **Centralized Configuration**: Introduced `CsrLiteConfig` for managing global settings (column names, logging levels, missing value handling)
- **Refactored Count Functions**: Decoupled calculation from formatting in `count.py` for better separation of concerns
- **Enhanced Testing**: Added integration tests and extended unit test coverage for `StudyPlan` functionality
- **Code Quality**: Resolved all static analysis errors (pyre, mypy, ruff) and fixed deprecation warnings

## Key Changes

### Added
- Centralized configuration system via `src/csrlite/common/config.py` with Pydantic-based `CsrLiteConfig`
- Structured logging initialization in `src/csrlite/__init__.py`
- Integration test covering full pipeline from plan loading to RTF generation (`tests/integration_test_pipeline.py`)
- Extended unit tests for StudyPlan (`tests/test_plan_extended.py`)
- Comprehensive CHANGELOG.md

### Changed
- **count.py refactoring**: Split `count_subject_with_observation` into `count_summary_data` (numeric) and `format_summary_table` (formatting)
- **Pydantic migration**: All `StudyPlan` related classes now use Pydantic models with validation
- Updated dependencies to enforce `pydantic>=2.0.0`
- Version bump to 0.2.0 in `pyproject.toml`

### Fixed
- All pyre, mypy, and ruff static analysis errors
- Polars `is_in` deprecation warning in `ae_specific.py`
- TypeError in `StudyPlan.__str__` where `Dict` was incorrectly instantiated
- Pyre search path configuration

## Test Plan
- [x] All existing tests pass
- [x] New integration test validates end-to-end pipeline
- [x] Extended unit tests increase coverage for plan.py
- [x] Static analysis tools (pyre, mypy, ruff) run without errors
- [x] No deprecation warnings from dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)