### PR TITLE
Add line indentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csrlite"
-version = "0.3.0"
+version = "0.3.1"
 description = "A hierarchical YAML-based framework for generating Tables, Listings, and Figures in clinical trials"
 authors = [
     {name = "Yilong Zhang", email = "elong0527@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csrlite"
-version = "0.3.1"
+version = "0.3.2"
 description = "A hierarchical YAML-based framework for generating Tables, Listings, and Figures in clinical trials"
 authors = [
     {name = "Yilong Zhang", email = "elong0527@gmail.com"},

--- a/src/csrlite/common/rtf.py
+++ b/src/csrlite/common/rtf.py
@@ -15,6 +15,7 @@ def create_rtf_table_n_pct(
     source: list[str] | str | None,
     borders_2: bool = True,
     orientation: str = "landscape",
+    hanging_indent: list[int] | None = None,
 ) -> RTFDocument:
     """
     Create a standardized RTF table document with 1 or 2 header rows.
@@ -29,6 +30,9 @@ def create_rtf_table_n_pct(
         source: Source string or list of source strings.
         borders_2: Whether to show borders for the second header row. Defaults to True.
         orientation: Page orientation, "landscape" or "portrait". Defaults to "landscape".
+        hanging_indent: Optional list of hanging indent values in twips for each column.
+            When specified, wrapped lines are indented by this amount while the first
+            line stays at the left margin. Use values like 200 for ~0.14 inch indent.
 
     Returns:
         RTFDocument object.
@@ -69,10 +73,11 @@ def create_rtf_table_n_pct(
         "rtf_page": RTFPage(orientation=orientation),
         "rtf_title": RTFTitle(text=title_list),
         "rtf_column_header": headers,
-        "rtf_body": RTFBody(
-            col_rel_width=col_widths,
+        "rtf_body": _create_rtf_body(
+            col_widths=col_widths,
             text_justification=["l"] + ["c"] * (n_cols - 1),
-            border_left=["single"] * n_cols,
+            hanging_indent=hanging_indent,
+            n_cols=n_cols,
         ),
     }
 
@@ -85,6 +90,28 @@ def create_rtf_table_n_pct(
     return RTFDocument(**rtf_components)
 
 
+def _create_rtf_body(
+    col_widths: list[float],
+    text_justification: list[str],
+    hanging_indent: list[int] | None,
+    n_cols: int,
+) -> RTFBody:
+    """Create RTFBody with optional hanging indent support."""
+    body_kwargs: dict[str, Any] = {
+        "col_rel_width": col_widths,
+        "text_justification": text_justification,
+        "border_left": ["single"] * n_cols,
+    }
+
+    if hanging_indent is not None:
+        # Hanging indent: left margin for all lines, negative first-line indent
+        # pulls the first line back to the left margin
+        body_kwargs["text_indent_left"] = hanging_indent
+        body_kwargs["text_indent_first"] = [-x for x in hanging_indent]
+
+    return RTFBody(**body_kwargs)
+
+
 def create_rtf_listing(
     df: pl.DataFrame,
     col_header: list[str],
@@ -93,6 +120,7 @@ def create_rtf_listing(
     footnote: list[str] | str | None,
     source: list[str] | str | None,
     orientation: str = "landscape",
+    hanging_indent: list[int] | None = None,
 ) -> RTFDocument:
     """
     Create a standardized RTF listing document.
@@ -121,10 +149,11 @@ def create_rtf_listing(
         "rtf_page": RTFPage(orientation=orientation),
         "rtf_title": RTFTitle(text=title_list),
         "rtf_column_header": headers,
-        "rtf_body": RTFBody(
-            col_rel_width=col_widths,
+        "rtf_body": _create_rtf_body(
+            col_widths=col_widths,
             text_justification=["l"] * n_cols,
-            border_left=["single"] * n_cols,
+            hanging_indent=hanging_indent,
+            n_cols=n_cols,
         ),
     }
 

--- a/tests/test_rtf.py
+++ b/tests/test_rtf.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import polars as pl
 from rtflite import RTFDocument
 
-from csrlite.common.rtf import create_rtf_table_n_pct
+from csrlite.common.rtf import create_rtf_listing, create_rtf_table_n_pct
 
 
 class TestRTF(unittest.TestCase):
@@ -17,6 +17,12 @@ class TestRTF(unittest.TestCase):
             {
                 "Col1": ["A", "B"],
                 "Col2": [1, 2],
+            }
+        )
+        self.df_long = pl.DataFrame(
+            {
+                "Description": ["Short text", "A very long description text"],
+                "Value": ["10", "20"],
             }
         )
 
@@ -64,3 +70,37 @@ class TestRTF(unittest.TestCase):
 
         doc.write_rtf(str(self.output_file))
         self.assertTrue(self.output_file.exists())
+
+    def test_create_rtf_table_with_hanging_indent(self) -> None:
+        """Test create_rtf_table_n_pct with hanging_indent parameter."""
+        doc = create_rtf_table_n_pct(
+            df=self.df_long,
+            col_header_1=["Description", "Value"],
+            col_header_2=None,
+            col_widths=[2.0, 1.0],
+            title="Hanging Indent Test",
+            footnote=None,
+            source=None,
+            hanging_indent=[200, 0],  # 200 twips for first column
+        )
+
+        self.assertIsInstance(doc, RTFDocument)
+        doc.write_rtf(str(self.output_file))
+        self.assertTrue(self.output_file.exists())
+
+    def test_create_rtf_listing_with_hanging_indent(self) -> None:
+        """Test create_rtf_listing with hanging_indent parameter."""
+        doc = create_rtf_listing(
+            df=self.df_long,
+            col_header=["Description", "Value"],
+            col_widths=[2.0, 1.0],
+            title="Listing with Hanging Indent",
+            footnote="Test footnote",
+            source="Test source",
+            hanging_indent=[200, 0],
+        )
+
+        self.assertIsInstance(doc, RTFDocument)
+        doc.write_rtf(str(self.output_file))
+        self.assertTrue(self.output_file.exists())
+

--- a/tests/test_rtf.py
+++ b/tests/test_rtf.py
@@ -103,4 +103,3 @@ class TestRTF(unittest.TestCase):
         self.assertIsInstance(doc, RTFDocument)
         doc.write_rtf(str(self.output_file))
         self.assertTrue(self.output_file.exists())
-

--- a/uv.lock
+++ b/uv.lock
@@ -687,7 +687,7 @@ toml = [
 
 [[package]]
 name = "csrlite"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
Added a configurable hanging_indent parameter to both  create_rtf_table_n_pct and create_rtf_listing functions:

How it works:

hanging_indent is a list of integers in twips (1440 twips = 1 inch)
Each value corresponds to a column
When text wraps to continuation lines, those lines are indented by the specified amount
The first line stays at the left margin (normal position)
Common values:

200 twips ≈ 0.14 inch
288 twips ≈ 0.2 inch
432 twips ≈ 0.3 inch